### PR TITLE
removing extra-android-support from the system report

### DIFF
--- a/system_report.sh
+++ b/system_report.sh
@@ -72,9 +72,6 @@ echo
 echo "* extras:"
 tree -L 2 ${ANDROID_HOME}/extras
 echo
-echo "* extra-android-support package version:"
-cat $ANDROID_HOME/extras/android/support/source.properties | grep 'Pkg.Revision='
-echo
 echo "* platforms:"
 ls -1 ${ANDROID_HOME}/platforms
 echo


### PR DESCRIPTION
the `extra-android-support` package is no longer available