### PR TITLE
removing "fastlane" item from the system report - it's in the "All Ruby GEMs" , was just a duplicate

### DIFF
--- a/system_report.sh
+++ b/system_report.sh
@@ -21,7 +21,6 @@ echo "=== Pre-installed tool versions ========"
 
 ver_line="$(gradle --version | grep 'Gradle ')" ;     echo "* Gradle: $ver_line"
 ver_line="$(mvn --version | grep 'Apache Maven')" ;   echo "* Maven: $ver_line"
-ver_line="$(fastlane --version | grep 'fastlane ' | tail -1)" ; echo "* Fastlane: $ver_line"
 ver_line="$( javac -version 2>&1 )" ;                 echo "* Java: $ver_line"
 
 if [[ ! -z "$BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK_LTS" ]] ; then


### PR DESCRIPTION
Same as https://github.com/bitrise-io/osx-box-bootstrap/pull/76 just for the Linux/Docker stacks